### PR TITLE
bugfix: search.rb had an authorized params typo

### DIFF
--- a/lib/tmdby/wrappers/search.rb
+++ b/lib/tmdby/wrappers/search.rb
@@ -64,7 +64,7 @@ module Tmdby
       self.fetch "tv",
                   optional_params,
                   query: query,
-                  authorized_params: ["query", "page", "language", "first_aid_date_year", "search_type"]
+                  authorized_params: ["query", "page", "language", "first_air_date_year", "search_type"]
     end
 
   end


### PR DESCRIPTION
A simple typo fix, without which one cannot search by tv show first aired date.
