### PR TITLE
1.9.x compatibility (replace named parameters with *args)

### DIFF
--- a/lib/tmdby/wrapper.rb
+++ b/lib/tmdby/wrapper.rb
@@ -45,10 +45,25 @@ module Tmdby
       end
     end
 
-    #
-    def self.fetch(route = "", *args, method: "get", post_params: [], authorized_params: [], disable_unknown_params: false, **params)
-      @params = params
-      @params.merge!(args[0]) if not args.empty?
+    def self.fetch(route = "", *args)
+
+      if args.length == 0
+        options = {}
+      elsif args.length == 1
+        options = args[0]
+      elsif args.length == 2
+        options = args[1].merge(args[0])
+      end
+
+      method = options.fetch(:method, 'get')
+      post_params = options.fetch(:post_params, [])
+      authorized_params = options.fetch(:authorized_params, [])
+      disable_unknown_params = options.fetch(:disable_unknown_params, false)
+      [:method, :post_params, :authorized_params, :disable_unknown_params].each do |key|
+        options.delete(key)
+      end
+
+      @params = options
 
       self.add_default_language if authorized_params.include?'language'
       self.verify_params authorized_params unless disable_unknown_params or authorized_params.include?"append_to_response"

--- a/tests/credentials.rb
+++ b/tests/credentials.rb
@@ -1,7 +1,7 @@
 # A valid API_KEY is required to run the test suite
-API_KEY = ""
+API_KEY = "18ceb39fc6163e6e06e85d55513a43ef"
 
 # A valid account is required to run the test suite
-USERNAME = ""
-PASSWORD = ""
+USERNAME = "sathya@hitfix.com"
+PASSWORD = "7ezZMawir"
 ACCOUNT_ID = 0

--- a/tests/minitest/wrappers/minitest_wrapper.rb
+++ b/tests/minitest/wrappers/minitest_wrapper.rb
@@ -8,20 +8,21 @@ class MinitestWrapper < Minitest::Test
     Tmdby::Setup.default_language = nil
   end
 
-  def multi_assert(result,
-                   uri:,
-                   http_verb:,
-                   code:,
-                   includes: nil,
-                   status_code: nil,
-                   id: nil,
-                   empty: nil,
-                   not_empty: nil,
-                   not_nil: nil,
-                   must_be_true: nil,
-                   must_be_false: nil,
-                   post_params: nil
-                  )
+  def multi_assert(result, params = {})
+    uri = params[:uri] || throw('missing uri') # required
+    http_verb = params[:http_verb] || throw('missing http_verb') # required
+    code = params[:code] || throw('missing code') # required
+
+    includes = params[:includes]
+    status_code = params[:status_code]
+    id = params[:id]
+    empty = params[:empty]
+    not_empty = params[:not_empty]
+    not_nil = params[:not_nil]
+    must_be_true = params[:must_be_true]
+    must_be_false = params[:must_be_false]
+    post_params = params[:post_params]
+
     assert_equal uri, result.uri.to_s
     assert_equal http_verb, result.http_verb
     assert_equal code, result.code


### PR DESCRIPTION
Fixes #2 (Syntax errors when using Ruby 1.9.3)

This replaces the Ruby 2 method signature syntax with something backwards-compatible with Ruby 1.9.x.

(Tests pass, except TMDb-rate-limit failures, which is normal. We may have to put delays between test runs to get a fully green suite. Or even better, use VCR to record the API calls and play them back locally. Anyway, I digress. That's for another day.)
